### PR TITLE
Fixed the extension for firefox v34 and higher

### DIFF
--- a/firefox-js/content/modules/common.jsm
+++ b/firefox-js/content/modules/common.jsm
@@ -32,6 +32,9 @@ Cu.import ("chrome://nrcwebcl/content/modules/lib_ocl/ocl_exception.jsm");
 Cu.import ("resource://gre/modules/ctypes.jsm");
 
 
+var console = Cu.import("resource://gre/modules/devtools/Console.jsm", {}).console;
+
+
 function getRuntimeABI ()
 {
   var xulRuntime = Cc["@mozilla.org/xre/app-info;1"].getService(Ci.nsIXULRuntime);
@@ -49,7 +52,7 @@ function getRuntimeOS ()
 function typedArrayToCTypesPtr (value)
 {
   var ptr = null, size = 0;
-
+  
   if (value.wrappedJSObject) value = value.wrappedJSObject;
 
   // NOTE: instanceof doesn't work when the object originates from different
@@ -63,80 +66,23 @@ function typedArrayToCTypesPtr (value)
     className = className.substring(0, className.lastIndexOf("]"));
   }
 
-  //if (value instanceof Int8Array)
-  if (className == "Int8Array")
-  {
-    //ptr = ctypes.int8_t.ptr (value);
-    ptr = ctypes.voidptr_t (value.buffer);
-    size = value.length * value.BYTES_PER_ELEMENT;
-  }
-  //else if (value instanceof Uint8Array)
-  else if (className == "Uint8Array")
-  {
-    //ptr = ctypes.uint8_t.ptr (value);
-    ptr = ctypes.voidptr_t (value.buffer);
-    size = value.length * value.BYTES_PER_ELEMENT;
-  }
-  //else if (value instanceof Uint8ClampedArray)
-  else if (className == "Uint8ClampedArray")
-  {
-    //ptr = ctypes.uint8_t.ptr (value);
-    ptr = ctypes.voidptr_t (value.buffer);
-    size = value.length * value.BYTES_PER_ELEMENT;
-  }
-  //else if (value instanceof Int16Array)
-  else if (className == "Int16Array")
-  {
-    //ptr = ctypes.int16_t.ptr (value);
-    ptr = ctypes.voidptr_t (value.buffer);
-    size = value.length * value.BYTES_PER_ELEMENT;
-  }
-  //else if (value instanceof Uint16Array)
-  else if (className == "Uint16Array")
-  {
-    //ptr = ctypes.uint16_t.ptr (value);
-    ptr = ctypes.voidptr_t (value.buffer);
-    size = value.length * value.BYTES_PER_ELEMENT;
-  }
-  //else if (value instanceof Int32Array)
-  else if (className == "Int32Array")
-  {
-    //ptr = ctypes.int32_t.ptr (value);
-    ptr = ctypes.voidptr_t (value.buffer);
-    size = value.length * value.BYTES_PER_ELEMENT;
-  }
-  //else if (value instanceof Uint32Array)
-  else if (className == "Uint32Array")
-  {
-    //ptr = ctypes.uint32_t.ptr (value);
-    ptr = ctypes.voidptr_t (value.buffer);
-    size = value.length * value.BYTES_PER_ELEMENT;
-  }
-  //else if (value instanceof Float32Array)
-  else if (className == "Float32Array")
-  {
-    //ptr = ctypes.float.ptr (value);
-    ptr = ctypes.voidptr_t (value.buffer);
-    size = value.length * value.BYTES_PER_ELEMENT;
-  }
-  //else if (value instanceof Float64Array)
-  else if (className == "Float64Array")
-  {
-    //ptr = ctypes.double.ptr (value);
-    ptr = ctypes.voidptr_t (value.buffer);
-    size = value.length * value.BYTES_PER_ELEMENT;
-  }
-  //else if (value instanceof ArrayBuffer)
-  else if (className == "ArrayBuffer")
-  {
-    ptr = T.voidptr_t (value);
-    size = value.byteLength;
-  }
-  else
-  {
-    throw new CLInvalidArgument ("");
+  switch(className) {
+    case "Int8Array":
+    case "Uint8Array":
+    case "Uint8ClampedArray":
+    case "Int16Array":
+    case "Uint16Array":
+    case "Int32Array":
+    case "Uint32Array":
+    case "Float32Array":
+    case "Float64Array":
+    case "ArrayBuffer":
+      ptr = value;
+      size = value.byteLength;
+      break;
+  default:
+    throw new CLInvalidArgument ("value", null, "Kernel.setArg");
   }
 
   return { ptr: ptr, size: size };
 }
-

--- a/firefox-js/content/modules/lib_ocl/kernel.jsm
+++ b/firefox-js/content/modules/lib_ocl/kernel.jsm
@@ -20,6 +20,7 @@ try {
 const Cu = Components.utils;
 
 Cu.import ("chrome://nrcwebcl/content/modules/logger.jsm");
+Cu.import ("chrome://nrcwebcl/content/modules/common.jsm");
 Cu.import ("resource://gre/modules/ctypes.jsm");
 Cu.import ("chrome://nrcwebcl/content/modules/lib_ocl/ocl_types.jsm");
 Cu.import ("chrome://nrcwebcl/content/modules/lib_ocl/ocl_symbols.jsm");
@@ -204,25 +205,13 @@ Kernel.prototype.setArg = function (index, value)
     ptr = value._internal.address();
     size = T.cl_sampler.size;
   }
-  else switch(className) {
-  case "Int8Array":
-  case "Uint8Array":
-  case "Uint8ClampedArray":
-  case "Int16Array":
-  case "Uint16Array":
-  case "Int32Array":
-  case "Uint32Array":
-  case "Float32Array":
-  case "Float64Array":
-    ptr = ctypes.voidptr_t (value.buffer);
-    size = value.byteLength;
-    break;
-  default:
-    throw new CLInvalidArgument ("value", null, "Kernel.setArg");
+  else {
+    let tmp = typedArrayToCTypesPtr(value);
+    ptr = tmp.ptr;
+    size = tmp.size;
   }
-
-  var err = this._lib.clSetKernelArg (this._internal, +index, size,
-                                      ctypes.cast(ptr, ctypes.voidptr_t));
+  
+  var err = this._lib.clSetKernelArg (this._internal, +index, size,  ptr);
   if (err) throw new CLError (err, null, "Kernel.setArg");
 };
 

--- a/firefox-js/install.rdf
+++ b/firefox-js/install.rdf
@@ -32,7 +32,7 @@ Project home page: http://webcl.nokiaresearch.com/
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
         <em:minVersion>34.0*</em:minVersion>
-        <em:maxVersion>37.*</em:maxVersion>
+        <em:maxVersion>44.*</em:maxVersion>
       </Description>
     </em:targetApplication>
 


### PR DESCRIPTION
These commits will make the extension work for any firefox version starting from v34.
I haven't tested any version lower that v34 since that's really old anyway.

What's changed:
 1. Commit 0ef05bb92fff41e4b0274e7f6b018e8a2956a749 added proper support for WebCL events, but OpenCL event callbacks are not guaranteed to be executed in the original thread, which is required by js-ctypes. Instead, the CallbackWorker will now wait for the event to be completed, and then fire the callback from within js.
2. Explicitely casting ArrayBuffers or TypedArrays to voidptr_t does not work anymore. And it's not even needed. js-ctypes will cast known types implicitely.

Notes:
 * Tutorial 3 and 4 do not fully work, as commandqueue.finish returns a webclevent that should be waited for. 
 * There's a rather huge memory leak when running the ray tracing demo.
