### PR TITLE
fix setting data in output buffers

### DIFF
--- a/firefox-js/content/modules/common.jsm
+++ b/firefox-js/content/modules/common.jsm
@@ -52,7 +52,7 @@ function getRuntimeOS ()
 function typedArrayToCTypesPtr (value)
 {
   var ptr = null, size = 0;
-  
+
   if (value.wrappedJSObject) value = value.wrappedJSObject;
 
   // NOTE: instanceof doesn't work when the object originates from different
@@ -76,6 +76,9 @@ function typedArrayToCTypesPtr (value)
     case "Uint32Array":
     case "Float32Array":
     case "Float64Array":
+      // ptr = value.buffer;
+      // size = value.byteLength;
+      // break;
     case "ArrayBuffer":
       ptr = value;
       size = value.byteLength;

--- a/firefox-js/content/modules/framescript/webcl.jsm
+++ b/firefox-js/content/modules/framescript/webcl.jsm
@@ -90,7 +90,7 @@ try
     obj._getTransient = createFnWrapper (ctx, className, "_getTransient");
 
     obj._getUUID = function () {
-      uuidGenerator.generateUUID().toString().slice(1,-1).replace("-", "", "g");
+      return uuidGenerator.generateUUID().toString().slice(1,-1).replace("-", "", "g");
     }
 
 //     Object.defineProperty (obj, "dumpTree",

--- a/firefox-js/content/modules/lib_ocl/kernel.jsm
+++ b/firefox-js/content/modules/lib_ocl/kernel.jsm
@@ -210,8 +210,8 @@ Kernel.prototype.setArg = function (index, value)
     ptr = tmp.ptr;
     size = tmp.size;
   }
-  
-  var err = this._lib.clSetKernelArg (this._internal, +index, size,  ptr);
+
+  var err = this._lib.clSetKernelArg (this._internal, +index, size, ptr);
   if (err) throw new CLError (err, null, "Kernel.setArg");
 };
 

--- a/firefox-js/content/page/clientwrapper.js
+++ b/firefox-js/content/page/clientwrapper.js
@@ -221,8 +221,8 @@
   _CommandQueue.prototype.enqueueBarrier = _createDefaultFunctionWrapper ("enqueueBarrier");
   _CommandQueue.prototype.enqueueWaitForEvents = _createDefaultFunctionWrapper ("enqueueWaitForEvents");
   _CommandQueue.prototype.finish = _createDefaultFunctionWrapper ("finish", commandQueue_finish_preproc, commandQueue_finish_postproc);
-  _CommandQueue.prototype.flush = _createDefaultFunctionWrapper ("flush");
-  _CommandQueue.prototype.release = _createDefaultFunctionWrapper ("release");
+  _CommandQueue.prototype.flush = _createDefaultFunctionWrapper ("flush", commandQueue_flush_preproc);
+  _CommandQueue.prototype.release = _createDefaultFunctionWrapper ("release", commandQueue_flush_preproc);
 
 
 function event_interceptor(argIndex){
@@ -267,6 +267,11 @@ function commandQueue_finish_postproc(rv, args, procCtx)
     return rv;
 }
 
+function commandQueue_flush_preproc(args, procCtx)
+{
+  this.__queuedEvents__ = [];
+  return args;
+}
 
   //
   function create_commandQueue_readBuffer_preproc (hostBufferArgIdx)

--- a/firefox-js/content/page/clientwrapper.js
+++ b/firefox-js/content/page/clientwrapper.js
@@ -201,6 +201,8 @@
   _CommandQueue.prototype.release = _createDefaultFunctionWrapper ("release");
 
 
+
+
   //
   function create_commandQueue_readBuffer_preproc (hostBufferArgIdx)
   {
@@ -261,7 +263,8 @@
 
             // Get compatible view to target buffer and set its contents from
             // the transient data.
-            (new Uint8Array(procCtx.targetBuf.buffer)).set(data);
+            //(new Uint8Array(procCtx.targetBuf.buffer)).set(data);
+            procCtx.targetBuf.set(data);
 
             if (okToRelease) ev.release ();
           });
@@ -283,12 +286,12 @@
 
       if (procCtx.sync)
       {
+        console.log(rv);
         if (!rv.error)
         {
           try{
-            let tmp = new Uint8Array(rv.value.x);
             let target = procCtx.originalArguments[hostBufferArgIdx];
-            (new Uint8Array(target.buffer)).set(tmp);
+            target.set(rv.value.x);
           }
           catch(e){
             console.error("[clientwrapper.js] create_commandQueue_readBuffer_postproc"+

--- a/firefox-js/content/page/clientwrapper.js
+++ b/firefox-js/content/page/clientwrapper.js
@@ -260,11 +260,9 @@
           ev.setCallback (WebCL.COMPLETE, function ()
           {
             var data = window.NRCWebCL.WebCL._getTransient (procCtx.transientObjectId);
-
             // Get compatible view to target buffer and set its contents from
             // the transient data.
-            //(new Uint8Array(procCtx.targetBuf.buffer)).set(data);
-            procCtx.targetBuf.set(data);
+            (new Uint8Array(procCtx.targetBuf.buffer)).set(data);
 
             if (okToRelease) ev.release ();
           });

--- a/firefox-js/content/page/clientwrapper.js
+++ b/firefox-js/content/page/clientwrapper.js
@@ -26,8 +26,30 @@
   _WebCL.prototype.createContext = _createDefaultFunctionWrapper ("createContext");
   _WebCL.prototype.getSupportedExtensions = _createDefaultFunctionWrapper ("getSupportedExtensions");
   _WebCL.prototype.enableExtension = _createDefaultFunctionWrapper ("enableExtension");
-  _WebCL.prototype.waitForEvents = _createDefaultFunctionWrapper ("waitForEvents");
+  _WebCL.prototype.waitForEvents = _createDefaultFunctionWrapper ("waitForEvents", waitforevents_preproc, waitforevents_postproc);
   _WebCL.prototype.releaseAll = _createDefaultFunctionWrapper ("releaseAll");
+
+  function waitforevents_preproc(args, procCtx)
+  {
+    var whenFinished = procCtx.originalArguments[1];
+    procCtx.sync = !(whenFinished && typeof(whenFinished) === "function")
+
+    if(!procCtx.sync){
+      args[1] = function(){
+        _runeventcallbacks(procCtx.originalArguments[0]);
+        whenFinished();
+      }
+    }
+    return args;
+  }
+
+  function waitforevents_postproc(rv, args, procCtx)
+  {
+      if(procCtx.sync){
+        _runeventcallbacks(procCtx.originalArguments[0]);
+      }
+      return rv;
+  }
 
   // Add WebCL enums
   for (let name in window.NRCWebCL.enums)
@@ -169,14 +191,16 @@
 
     this._connector = window.NRCWebCL.WebCLCommandQueue;
     this._name = "WebCLCommandQueue";
+
+    this.__queuedEvents__ = [];
   }
   _CommandQueue.prototype = Object.create (_Base.prototype);
 
-  _CommandQueue.prototype.enqueueCopyBuffer = _createDefaultFunctionWrapper ("enqueueCopyBuffer");
-  _CommandQueue.prototype.enqueueCopyBufferRect = _createDefaultFunctionWrapper ("enqueueCopyBufferRect");
-  _CommandQueue.prototype.enqueueCopyImage = _createDefaultFunctionWrapper ("enqueueCopyImage");
-  _CommandQueue.prototype.enqueueCopyImageToBuffer = _createDefaultFunctionWrapper ("enqueueCopyImageToBuffer");
-  _CommandQueue.prototype.enqueueCopyBufferToImage = _createDefaultFunctionWrapper ("enqueueCopyBufferToImage");
+  _CommandQueue.prototype.enqueueCopyBuffer = _createDefaultFunctionWrapper ("enqueueCopyBuffer", event_interceptor(6));
+  _CommandQueue.prototype.enqueueCopyBufferRect = _createDefaultFunctionWrapper ("enqueueCopyBufferRect", event_interceptor(10));
+  _CommandQueue.prototype.enqueueCopyImage = _createDefaultFunctionWrapper ("enqueueCopyImage", event_interceptor(6));
+  _CommandQueue.prototype.enqueueCopyImageToBuffer = _createDefaultFunctionWrapper ("enqueueCopyImageToBuffer", event_interceptor(6));
+  _CommandQueue.prototype.enqueueCopyBufferToImage = _createDefaultFunctionWrapper ("enqueueCopyBufferToImage", event_interceptor(6));
 
   _CommandQueue.prototype.enqueueReadBuffer = _createDefaultFunctionWrapper ("enqueueReadBuffer",
     create_commandQueue_readBuffer_preproc(4),
@@ -188,19 +212,60 @@
     create_commandQueue_readBuffer_preproc(5),
     create_commandQueue_readBuffer_postproc(5));
 
-  _CommandQueue.prototype.enqueueWriteBuffer = _createDefaultFunctionWrapper ("enqueueWriteBuffer");
-  _CommandQueue.prototype.enqueueWriteBufferRect = _createDefaultFunctionWrapper ("enqueueWriteBufferRect");
-  _CommandQueue.prototype.enqueueWriteImage = _createDefaultFunctionWrapper ("enqueueWriteImage");
+  _CommandQueue.prototype.enqueueWriteBuffer = _createDefaultFunctionWrapper ("enqueueWriteBuffer", event_interceptor(6));
+  _CommandQueue.prototype.enqueueWriteBufferRect = _createDefaultFunctionWrapper ("enqueueWriteBufferRect", event_interceptor(11));
+  _CommandQueue.prototype.enqueueWriteImage = _createDefaultFunctionWrapper ("enqueueWriteImage", event_interceptor(7));
 
-  _CommandQueue.prototype.enqueueNDRangeKernel = _createDefaultFunctionWrapper ("enqueueNDRangeKernel");
-  _CommandQueue.prototype.enqueueMarker = _createDefaultFunctionWrapper ("enqueueMarker");
+  _CommandQueue.prototype.enqueueNDRangeKernel = _createDefaultFunctionWrapper ("enqueueNDRangeKernel", event_interceptor(6));
+  _CommandQueue.prototype.enqueueMarker = _createDefaultFunctionWrapper ("enqueueMarker", event_interceptor(0));
   _CommandQueue.prototype.enqueueBarrier = _createDefaultFunctionWrapper ("enqueueBarrier");
   _CommandQueue.prototype.enqueueWaitForEvents = _createDefaultFunctionWrapper ("enqueueWaitForEvents");
-  _CommandQueue.prototype.finish = _createDefaultFunctionWrapper ("finish");
+  _CommandQueue.prototype.finish = _createDefaultFunctionWrapper ("finish", commandQueue_finish_preproc, commandQueue_finish_postproc);
   _CommandQueue.prototype.flush = _createDefaultFunctionWrapper ("flush");
   _CommandQueue.prototype.release = _createDefaultFunctionWrapper ("release");
 
 
+function event_interceptor(argIndex){
+  return function(args, procCtx){
+    var ev = procCtx.originalArguments[argIndex];
+    if (ev){
+      if(ev instanceof window.WebCLEvent) {
+        this.__queuedEvents__.push(ev);
+      }
+    }
+    return args;
+  };
+}
+
+function _runeventcallbacks(eventlist){
+  for(var i = 0; i < eventlist.length; i++){
+    eventlist[i].__runCallbacksSync__();
+  }
+}
+
+function commandQueue_finish_preproc(args, procCtx)
+{
+  var whenFinished = procCtx.originalArguments[1];
+  procCtx.sync = !(whenFinished && typeof(whenFinished) === "function")
+
+  if(!procCtx.sync){
+    args[1] = function(){
+      _runeventcallbacks(this.__queuedEvents__);
+      this.__queuedEvents__ = [];
+      whenFinished();
+    }
+  }
+  return args;
+}
+
+function commandQueue_finish_postproc(rv, args, procCtx)
+{
+    if(procCtx.sync){
+      _runeventcallbacks(this.__queuedEvents__);
+      this.__queuedEvents__ = [];
+    }
+    return rv;
+}
 
 
   //
@@ -257,17 +322,21 @@
           // Hook to COMPLETE event. Then get the transient data containing
           // the actual result ArrayBuffer content from the frame script.
           // Finally, write new data to original argument TypedArray.
-          ev.setCallback (WebCL.COMPLETE, function ()
-          {
+          //
+          ev.setCallback (WebCL.COMPLETE, function() {
             var data = window.NRCWebCL.WebCL._getTransient (procCtx.transientObjectId);
             // Get compatible view to target buffer and set its contents from
             // the transient data.
             (new Uint8Array(procCtx.targetBuf.buffer)).set(data);
-
+            //procCtx.targetBuf.set(data);
+            //
             if (okToRelease) ev.release ();
           });
+
+          this.__queuedEvents__.push(ev);
         }
         catch (e) {
+          console.error(e);
           // Failed to mangle args, maybe the typed array wasn't a typed array.
           procCtx.failure = true;
           args[hostBufferArgIdx] = procCtx.originalArguments[hostBufferArgIdx];
@@ -377,14 +446,51 @@
 
     this._connector = window.NRCWebCL.WebCLEvent;
     this._name = "WebCLEvent";
+
+    this.__callbacks__ = [];
+
   }
   _Event.prototype = Object.create (_Base.prototype);
 
   _Event.prototype.getProfilingInfo = _createDefaultFunctionWrapper ("getProfilingInfo");
-  _Event.prototype.setCallback = _createDefaultFunctionWrapper ("setCallback");
+  _Event.prototype.setCallback = _createDefaultFunctionWrapper ("setCallback", event_set_callback_preproc, event_set_callback_postproc);
   _Event.prototype.release = _createDefaultFunctionWrapper ("release");
 
+function event_set_callback_preproc(args, procCtx)
+{
+    var notify = procCtx.originalArguments[1];
+    var callbackfn = function(){
+      if(callbackfn.__finished__){
+        return;
+      }
+      try {
+        notify.apply(null, arguments)
+      }
+      finally{
+        callbackfn.__finished__ = true;
+      }
+    }
+    callbackfn.__finished__ = false;
 
+    args[1] = callbackfn;
+
+    this.__callbacks__.push({ type: args[0], fn: args[1] });
+    return args;
+}
+
+function event_set_callback_postproc(rv, args, procCtx)
+{
+    return rv;
+}
+
+
+
+  _Event.prototype.__runCallbacksSync__ = function(){
+    for (var i = 0; i < this.__callbacks__.length; i++) {
+      //TODO: run callback conditionally for the given status
+      this.__callbacks__[i].fn.call(null);
+    }
+  }
 
   // == UserEvent ================================================================
   function _UserEvent (identity) {
@@ -577,7 +683,7 @@
 
         if (preProcFn && typeof(preProcFn) == "function")
         {
-          args = preProcFn (args, procCtx);
+          args = preProcFn.call(this, args, procCtx);
         }
 
 
@@ -606,7 +712,7 @@
 
         if (postProcFn && typeof(postProcFn) == "function")
         {
-          rv = postProcFn (rv, args, procCtx);
+          rv = postProcFn.call(this, rv, args, procCtx);
         }
 
         rv = _wrap_rv (rv);

--- a/firefox-js/install.rdf
+++ b/firefox-js/install.rdf
@@ -31,7 +31,7 @@ Project home page: http://webcl.nokiaresearch.com/
       <!-- Firefox -->
       <Description>
         <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
-        <em:minVersion>34.0*</em:minVersion>
+        <em:minVersion>31.0*</em:minVersion>
         <em:maxVersion>44.*</em:maxVersion>
       </Description>
     </em:targetApplication>


### PR DESCRIPTION
This commit fixes reading out the data with CommandQueue.readBuffer, when using anything else than Uint8Arrays.
To correct my earlier pull request: Tutorial 3 and 4 are not ill-formed, the extension just does not (yet) work for asynchronous operations. When changing the tutorials to use blocking queuing operations, it does work as expected.